### PR TITLE
Typos and minor English usage errors

### DIFF
--- a/documents/CWP/cwp-wg-visualization.tex
+++ b/documents/CWP/cwp-wg-visualization.tex
@@ -335,10 +335,10 @@ on top of the effort needed for the development and maintanance of the event dis
 
 Other applications use higher-level interface libraries as graphics engines. This has the advantage of delegating
 a large part of the lower-level development work to external software packages, leaving the developers to concentrate
-on the application development itself. A popular grpahics library used in HEP software has been
+on the application development itself. A popular graphics library used in HEP software has been
 Open Inventor~\cite{OpenInventor1993}, used by the defunct CMS Iguana~\cite{CMSIguanaPaperNIM,CMSIguana} application, or
 its clone implementation Coin (also known as Coin3D)~\cite{Coin3D}, which has been used by applications such
-the ATLAS VP1~\cite{ATLASVP12010}, the LHCb Panoramix~\cite{LHCbPanoramix} and the defunct desktop version of the
+as ATLAS VP1~\cite{ATLASVP12010}, LHCb Panoramix~\cite{LHCbPanoramix} and the defunct desktop version of the
 CMS iSpy application~\cite{CMSISpy}. Coin / Open Inventor was
 chosen because of its integrability in C++ code, its performance, and its coding style. Moreover, the way Open Inventor handles
 graphical volumes could be easily matched with the way geometry volumes are handled to describe the detectors in HEP experiments.
@@ -386,10 +386,10 @@ However, mobile devices still do not have the computing power usually needed for
 are retrieved and processed. In addition they usually run dedicated operating systems whose self-contained nature
 makes their integration within the HEP workflow difficult, particularly for the statistical-based visualization used in
 data analysis, described in Section~\ref{statistical-data-visualization}. Despite the current limitations for these use-cases mobile
-devices can be found in the current landscape of event display.
+devices can be found in the current landscape of event displays.
 
 Several event display applications have been developed for, or at least can be run on, mobile devices.
-An example of a native application is LHSee~\cite{LHSee} which live-streamed ATLAS events, processed and extracted
+An example of a native application is LHSee~\cite{LHSee} which live-streams ATLAS events, processed and extracted
 through Atlantis~\cite{ATLASAtlantis},
 to a user’s phone and provided contextual information on ATLAS and the
 events being displayed. The CMS iSpy WebGL application~\cite{CMSISpyWebGL} runs on mobile devices in the browser.
@@ -437,7 +437,7 @@ detector geometries and are used to provide visual context only.
 
 Currently, different geometry formats and libraries are used in HEP. 
 Some experiments use their own custom format (\textit{e.g.}, \cite{ATLASGeoModel2004}), while others use the geometry tools provided by the ROOT framework~\cite{Root1997}.
-More recently, some attempts have been done in order to build common formats and libraries for detector geometry, like DD4HEP~\cite{dd4hep},
+More recently, some attempts have been made to build common formats and libraries for detector geometry, like DD4HEP~\cite{dd4hep},
 adopted in conceptual design studies for future high-energy colliders, including the CLICdp~\cite{clicdp} and FCC~\cite{fcc} collaborations.
 In all cases detector volumes are built from simpler geometrical entities: geometrical shapes like Tube, Cone, Box, and
 more complex variations of these are combined in order to build the volumes of the experiment’s geometry.
@@ -446,7 +446,7 @@ Geometry libraries and formats are also described in the HSF \textit{Detector Si
 The differences in geometry formats used by the different experiments, by detector simulation programs like Geant4~\cite{Geant4},
 and by data analysis frameworks like ROOT, typically require developers of visualization applications to write converters
 between the different formats. In addition it is often not easy to use a visualization tool developed for one experiment with another one as
-because current visualization tools are often tightly bound to the geometry library used by the experiment.
+current visualization tools are often tightly bound to the geometry library used by the experiment.
 
 In framework-based applications the geometry information can come directly from the experiment's detector description and in
  many cases the hierarchical structure of the detector description is preserved and accessible. Standalone applications
@@ -495,7 +495,7 @@ detailed simulation geometry can be available in a standalone application.
 \epigraph{The simple graph has brought more information to the data analyst's mind than any other device.}{\textit{John Tukey \cite{Tukey1962}}}
 
 Data visualization also means visualizing quantities and properties taken from a series of events, in order to extract statistical
-meaning from them. An example of statistical data visualizations are histograms and scatter plots.
+meaning from them. Examples of statistical data visualizations are histograms and scatter plots.
 
 In HEP, like most other scientific disciplines, visualization of the data and of the final results plays a key role in the
 analysis pipeline. A new projection of the data may provide new insight, results must be summarized in a
@@ -503,12 +503,12 @@ clear and concise way, and multidimensional parameter spaces need to be visualiz
 of how to properly display data is not new~\cite{Tufte1986}, but the tools are constantly evolving. Since its introduction 20 years ago,
 ROOT~\cite{Root1997} has become the most widely used package in HEP to make plots, graphics, and even to build event displays.
 It was developed at a time when there were few alternatives for the HEP community that did not have a significant
-financial cost and it has performed admirably.
+financial cost, and it has performed admirably.
 
 However, the landscape is changing and there are several existing tools driven by non-HEP communities available. This section will look at
 some of the current alternatives and comment on what options might be available in the future and what our needs are. The main focus is
-on the data exploration and presentation tools. The former describe tools with which one prepares and build visualization for the purpose
-of exploring and attempting to understand one's dataset. The latter describes tools for presentation of final plot in a convenient and accesible way.
+on data exploration and presentation tools. The former describes tools with which one prepares and builds visualizations for the purpose
+of exploring and attempting to understand one's dataset. The latter describes tools for the presentation of final plots in a convenient and accesible way.
 For more details on data analysis itself, one should refer to the HSF \emph{Data Analysis and Interpretation} Community White Paper~\cite{HSF-CWP-2017-05}.
 
 \hypertarget{stats-desktop}{%
@@ -517,10 +517,10 @@ For more details on data analysis itself, one should refer to the HSF \emph{Data
 As it stands, ROOT is the most widely adopted plotting tool within the HEP and Nuclear Physics community.
 It has even made some inroads to the astrophysics community and some small pockets within the financial community,
 to where some physicists migrated. However, few other disciplines have adopted it. Still, it has many features beyond
-the standard 1D/2D/3D histogram/graphing tools such as 2D and 3D shapes, widgets for building a GUI, a JavaScript
+the standard 1D/2D/3D histogram/graphing tools, such as 2D and 3D shapes, widgets for building a GUI, a JavaScript
 implementation for web-based analysis~\cite{rootjs} and is available within a Jupyter notebook~\cite{JupyterNotebook}. But to
 access the plotting features, an analyst must install the entire ROOT package which includes file I/O, scientific
-libraries, fitting routines, etc.\ and often the installation process is non-trivial.
+libraries, fitting routines etc.,\ and often the installation process is non-trivial.
 
 Many current HEP analysts make wide use of the Python programming language and the PyROOT libraries~\cite{PyROOT}.
 Python is also very popular outside the HEP community and so it is worth looking at non-ROOT options available to Python users.
@@ -542,9 +542,9 @@ but you cannot do anything more significant with other mouseover commands (links
 multidimensional parameter spaces. \textit{ggplot2} is an implementation of the guidelines contained in the classic
 text \textit{The Grammar of Graphics}~\cite{Wilkinson2005}, while \textit{lattice} is an implementation of the
 so-called \textit{Trellis Display}~\cite{Trellis}. Both packages are very popular outside the HEP community and a wide range
-of learning materials are available in books, online courses, and other media. Both packages are well developed and matured
-and offer mechanism for users to extend them by adding new features.
-\textit{lattice} has longer history: in 2005, the year \textit{ggplot2} first appeared, \textit{lattice} was already popular.
+of learning materials are available in books, online courses, and other media. Both packages are well developed and mature
+and offer mechanisms for users to extend them by adding new features.
+\textit{lattice} has a longer history: in 2005, the year \textit{ggplot2} first appeared, \textit{lattice} was already popular.
 In fact, figures made with \textit{lattice} were shown in the
 presentation in PHYSTAT05~\cite{phystat05} which introduced R to the
 particle physics community.
@@ -582,7 +582,7 @@ The so-called notebooks are a rapidly evolving way of using web-based technology
 visualization, with access to local resources as well. After having started from a Mathematica-like notebook user interface
 paradigm mixing server-side code snippet execution, structured text, and (mostly) static visualizations, the Jupyter community
 is now exploring more interactive user interface paradigms, including in the area of visualization. The JupyterLab project is
-exploring a more MATLAB-like IDE user experience inside of the web browser, with features such as multiple source editing tabs
+exploring a more MATLAB-like IDE user experience inside the web browser, with features such as multiple source editing tabs
 and interactive python consoles. Its ipywidgets sub-project tries to make Jupyter more interactive by moving more visualization
 work to client-side Javascript and introducing classic GUI widgets such as sliders and checkboxes for interacting with the live visualization.
 The Belle II experiment has started to use Jupyter notebooks to train new users in data analysis; the learning curve is much gentler than in
@@ -643,7 +643,7 @@ Networks and graphs are very effective ways of visualizing tree-like data, becau
 		\label{fig:atlasgeo2}
 	\end{subfigure}
 	\caption[Using 3D editing software for HEP Geometry]
-	{\small \subref{fig:atlasgeo1}) a schematic drawing depicting the tree-structure of the data describing the geometry of the ATLAS detector. Data structure in such a way are better visualized using graphs and networks. \subref{fig:atlasgeo2}) a graph visualizing the first layer of the nodes of the ATLAS Detector Description. Different colors indicate different types of nodes; also, the labels along the lines state the different types of relationship between two data nodes. \cite{ATLASGeoModel2017}.}
+	{\small \subref{fig:atlasgeo1}) A schematic drawing depicting the tree-structure of the data describing the geometry of the ATLAS detector. Such data structures are better visualized using graphs and networks. \subref{fig:atlasgeo2}) A graph visualizing the first layer of the nodes of the ATLAS Detector Description. Different colors indicate different types of nodes; also, the labels along the lines state the different types of relationship between two data nodes \cite{ATLASGeoModel2017}.}
 	\label{fig:atlasgeotree}
 \end{figure*}
 
@@ -653,7 +653,7 @@ Another example of HEP data that can benefit from a graph-based visualization is
 used to filter and reconstruct the experimental data. Very recently HEP experiments began to develop new parallel frameworks
 to concurrently handle analysis or reconstruction jobs, to efficiently exploit the parallelism offered by the modern hardware
 (more details can be found in the HSF \textit{Event/Data Processing Frameworks} Community White Paper~\cite{HSF-CWP-2017-08}).
-The jobs are handled by a scheduler, which organize them according to their need input and output data. The outcome of the scheduler
+The jobs are handled by a scheduler, which organizes them according to their needed input and output data. The outcome of the scheduler
 is a directed acyclic graph (DAG). The visualization of that by mean of a graph helps the developer understanding and debugging the
 reconstruction code and the experiment’s framework itself.
 
@@ -671,9 +671,9 @@ networks used to transfer data between GRID sites \cite{neo4jnetworkstudy} (see 
 
 
 All those data are not space- nor time-dependent, and they are better visualized through a graph or a network. Graph-based visualization,
-as well as graph-databases, are somehow new in the HEP landscape; but they can be very powerful tools to effectively visualize
+as well as graph-databases, are fairly new in the HEP landscape; but they can be very powerful tools to effectively visualize
 non-spatial data which are by their nature organized with a network layout. We suggest the community to further explore those tools,
-to better understand the possibility offered by graph-based solutions for the HEP needs.
+to better understand the possibility offered by graph-based solutions for HEP needs.
 
 
 % More examples from the other experiments, if any and if possible... ==> I didn't find any other example]

--- a/documents/CWP/cwp-wg-visualization.tex
+++ b/documents/CWP/cwp-wg-visualization.tex
@@ -261,7 +261,7 @@ those platforms officially supported by the experiment. It is then possible to h
 which can be easily and broadly distributed. %even for outreach and educational activities for the general public.
 
 The primary drawback to this approach is that, with no direct access to the experimental data, some
-some information is necessarily not accessible. Moreover, every time there is the need to modify the content of the
+information is necessarily not accessible. Moreover, every time there is the need to modify the content of the
 intermediate data files, one needs to run the data extraction tools on the native data again.
 In addition to that, only events which are identified as potentially interesting are extracted and their
 data reduced to be stored in the intermediate data file; so, if the end user wants to analyze and visualize other
@@ -276,7 +276,7 @@ seen in Figure~\ref{fig:eventdisplaysapplicationstypes}.
 	\includegraphics[width=\linewidth]{img/eventDisplays_applications_types}
 	\caption[Different types of event display applications]{The two different types of event display applications. At the top,
 	the framework-integrated event display application is able to access all experimental data, all services, APIs, and databases
-	provided by the experimenbt's framework; as a drawback, the application must be run on specific platforms supported by the
+	provided by the experiment's framework; as a drawback, the application must be run on specific platforms supported by the
 	framework and it must use only graphics and GUI libraries compatible with them. At the bottom, the standalone approach, where
 	experimental data are accessed, filtered, and extracted by using custom data exporters, which create intermediate data files
 	containing only the interesting pieces of information; then, a standalone event display application reads those data in and it

--- a/documents/CWP/cwp-wg-visualization.tex
+++ b/documents/CWP/cwp-wg-visualization.tex
@@ -698,14 +698,14 @@ Let us take the example of the detector geometry. There are very many different 
 However, geometry libraries are all different ways to describe and handle basic geometrical entities and combinations of them.
 From a visualization point of view, the output of all geometry libraries are mere descriptions of 3D shapes, which could be abstracted
 from the underlying actual implementation. A shape like a box, or a cone, or a tube, or some boolean combination of them, could be
-interpreted and handled the same by a visualization tool in all experiments.
+interpreted and handled the same way by a visualization tool in all experiments.
 
 The same reasoning made for the geometry can be done for the event data. Of course different experiments detect different objects
 and measure different quantities, but there are many common entities, especially among experiments within the same research field.
 For example, all experiments working on hadron colliders use the notion of particle track, which is usually constructed translating
 the track measurements into space points or points and angles, and use the notion of particle jet, usually
 visualized as a cone whose length is related to its energy and whose radius is linked to the specific algorithm used for the jet
-reconstruction. Both of these objects are currently often handled and visualized differently in different experiments, but could in-principle
+reconstruction. Both of these objects are currently often handled and visualized differently in different experiments, but could in principle
 be the target of a common definition within the community. If so, experiments could share best practices or snippets of code,
 if not complete basic tools, to build and handle their visualization. In this way, the know-how and the tools linked to visualization needs
 could be shared as well, and developed in a collaborative way.
@@ -735,7 +735,7 @@ FBX geometry to the glTF format~\cite{glTF}, an emerging royalty-free specificat
 via the SketchFab community repository~\cite{SketchFabBelleII,SketchFab}. Displays based on three.js have access to multiple importers and exporters
 of several geometry formats, including the ones mentioned above. %For the near future, we will foster similar experiments within the community.
 
-In order to start sharing the knowledge and to start working on demonstrators to show and share best practices, we propose to start
+In order to start sharing knowledge and to start working on demonstrators to show and share best practices, we propose to start
 defining a common format to exchange data among the experiments. We should start by finding and listing common shared objects from
 geometry and event data. After that, we should start converging on a shared definition of those objects, to build a common design
 toward a data model to handle and serve them. The idea, in fact, is to enable usage of this common format to visualize data from
@@ -775,7 +775,7 @@ In addition, simulation data description for visualization could be handled in t
 generators and simulation applications.
 
 After a first phase of development and stand-alone testing, the streamed data could be used by the current visualization tools as well,
-as first step of their modernization and towards the usage of common community-developed techniques and best practices.
+as the first step of their modernization and towards the usage of common community-developed techniques and best practices.
 
 \hypertarget{client-server}{%
 \subsection{Client-server architecture for geometry and event data visualization}\label{client-server}}
@@ -784,8 +784,8 @@ After common data formats and mechanisms to serve them are designed, together wi
 data to the common format, we are proposing to build a client-server architecture, upon which next generation visualization applications can be built.
 
 The idea behind that is that if we can send commands from the client to the server, and get the answer back in the data stream, then
-we will be able to interact with the experiment’s framework as well, in addition of using common visualization applications to visualize
-the common objects. In this way, we will achieve to develop a modular architecture where HEP experiments could share the design, the
+we will be able to interact with the experiment’s framework as well, in addition to using common visualization applications to visualize
+the common objects. In this way, we can develop a modular architecture where HEP experiments can share the design, the
 development and the maintenance of common visualization tools, while maintaining a certain degree of freedom to add custom content
 and objects and to interact with their own framework to retrieve specific content.
 
@@ -796,9 +796,9 @@ and objects and to interact with their own framework to retrieve specific conten
 \subsubsection{Graphics and game engines}\label{graphic-engines}}
 
 So far direct OpenGL, its derivatives (like WebGL), or old graphics libraries have been used in HEP visualization applications. Nowadays,
-another type of graphics library is rapidly evolving, those embedded in the so-called game engines. Game engines software frameworks targeted
+another type of graphics library is rapidly evolving, those embedded in so-called game engines. Game engines are software frameworks targeted
 at the gaming industry, and they feature very efficient, optimized, and modern 3D graphics.
-The integration with existing code is not easy, however, because they are usually meant to be used as development environments,
+Integration with existing code is not easy, however, because they are usually meant to be used as development environments,
 and not as embedded libraries like those commonly used in HEP. So they would probably require some major changes in the usual
 software architecture used in HEP. But they offer very optimized graphics and modern features, like tools for Virtual Reality,
 which could be exploited in our applications.
@@ -831,7 +831,7 @@ C\# or an adaptation of Javascript.
 Another game engine that has gained attention in recent years is the open-source engine Godot~\cite{Godot}.
 While it is still not quite at the same level as Unity or Unreal Engine, it allows the deployment to similar platforms as Unity and Unreal
 Engine but is very lightweight.
-It offers the support for 2D and 3D graphics and for multiple programming languages {\it e.g.}\ GDScript (a Python-like scripting language),
+It offers support for 2D and 3D graphics and for multiple programming languages {\it e.g.}\ GDScript (a Python-like scripting language),
  C\# 7.0 (by using Mono), and C++.
 It also offers visual scripting using blocks and connections and support for additional languages with
 community-provided support for Python, Nim~\cite{nimLang}, D and other languages.
@@ -841,7 +841,7 @@ look at possible usage patterns in the context and within the workflow of HEP vi
 
 Finally, another new entry in the 3D graphics engines landscape is Qt3D~\cite{Qt3d}. The key feature of Qt3D is that it is natively integrated with the Qt framework, which eliminates a layer which was needed until now, \textit{i.e.}, a glue
 package to connect the Qt GUI with the window showing the 3D content (like, for example, the SoQt~\cite{soqt} package used by ATLAS). By eliminating that, we could simplify the architecture
-of our visualization tools and lower the maintenance work. Qt3D is still in development, but it shows an initial set of
+of our visualization tools and lower the maintenance workload. Qt3D is still in development, but it shows an initial set of
 features which are worth a further consideration of the new toolkit. We plan to take a look at its development in the near future,
 to see if it can satisfy the HEP requirements. Also, being open source, we could consider contributing to the Qt3D software
 project as a community, by providing the pieces we need for our applications.
@@ -850,8 +850,8 @@ project as a community, by providing the pieces we need for our applications.
 \subsubsection{Web-based applications}\label{web-based}}
 
 Web-based graphics have traditionally been considered not powerful enough to handle the thousands of volumes that can be
-shown in a HEP event displays, for example, when visualizing hits in a very busy event. But the technology has rapidly
-evolved and Web-based graphics can now visualize very complex scenes.
+shown in HEP event displays, for example, when visualizing hits in a very busy event. But the technology has rapidly
+evolved and web-based graphics can now visualize very complex scenes.
 For example, the glTF~\cite{glTF} 3D model of the Belle II detector~\cite{BelleII}, with tens of thousands of elements,
 can be loaded, viewed and manipulated in a web browser, even on a smartphone, very effectively~\cite{SketchFabBelleII}.
 
@@ -859,14 +859,14 @@ can be loaded, viewed and manipulated in a web browser, even on a smartphone, ve
 The advantages of visualization in the browser have been mentioned
 previously and several application have already been developed.
 There is therefore already a strong interest in the community in supporting the usage and the development of web-based tools.
-In particular, JSROOT~\cite{rootjs} could be used as
+In particular, JSROOT~\cite{rootjs} could be used as an
 underlying layer for event data visualization as well as three.js~\cite{ThreeJS} and WebGL~\cite{WebGL2011}, which have been
 used successfully by different experiments (\textit{e.g.}, \cite{ATLASTada2016,ATLASTracer2015,CMSISpyWebGL}) to visualize geometry and event data.
 
 \hypertarget{vr}{%
 \subsubsection{Virtual and augmented reality}\label{vr}}
 
-As briefly described in Section \ref{application-development}, Virtual reality (VR) describes the simulation of the user’s
+As briefly described in Section \ref{application-development}, Virtual Reality (VR) describes the simulation of the user’s
 physical presence in a virtual environment. This simulation
 is typically delivered via a Head Mounted Display (HMD) that provides visual and aural experience of the simulated world.
 Rotational and positional tracking of the user’s head and hand motion (when available) allow for interaction and navigation
@@ -890,14 +890,14 @@ is another headset powered by an inserted smartphone targeted for the Oculus pla
 
 Currently, the most immersive and interactive VR environments are provided by the Oculus Rift~\cite{OculusRift} and the
 HTC Vive~\cite{HTCVive}, which combine the computing resources of a desktop machine with sensors, controllers, and high-quality HMDs.
-Those sophisticated devices are quite expensive (even if prices are lowering in the last months) and require a quite powerful computer to run.
-The presence of a proper computer lets solve the performance issue of phone-based viewers, since the 3D graphics computations are handled
-by the computer, but that also rise the initial budget for people willing to test such technologies, and that limits the number of
-people getting access to such platforms, as like as their usage in public events organized by HEP institutes.
+Those sophisticated devices are quite expensive (even if prices are lowering in the last months) and require a fairly powerful computer to run.
+The presence of a proper computer solves the performance issue of phone-based viewers, since the 3D graphics computations are handled
+by the computer, but that also increases the required initial budget for people willing to test such technologies, and that limits the number of
+people getting access to such platforms, for example in public events organized by HEP institutes.
 
-In between, a new type of device has been recently developed: a standalone viewer, equipped with an on-board CPU, able to run
+Meanwhile, a new type of device has been recently developed: a standalone viewer, equipped with an on-board CPU, able to run
 medium computation-intensive applications. Those devices lower the budget needed to develop and deploy VR applications significantly.
-One example of those new devices is Oculus Go\cite{OculusGo} and the stand-alone Lenovo headset for the
+Examples of those new devices are Oculus Go\cite{OculusGo} and the stand-alone Lenovo headset for the
 Daydream environment~\cite{LenovoMirageSolo}.
 
 Game engines, described in Section~\ref{graphic-engines},  provide powerful integrated development environments for
@@ -918,7 +918,7 @@ The More-Than-ALICE~\cite{MoreThanALICE} application allows users to superimpose
 ALICE detector (for example, on a screen or during public visits to the experimental site) or its paper model.
 
 Development of web-based VR and AR applications for mobile browser can be done using a WebGL library such as three.js~\cite{ThreeJS} and using the
-HTML device orientation control API. The viewport is split into two views for each eye, each with dedicated camera view separated
+HTML device orientation control API. The viewport is split into two views, one for each eye, each with a dedicated camera view separated
 by an appropriate distance to create a stereoscopic effect ({\it e.g.}\ iSpy WebGL~\cite{CMSISpyWebGL} has a stereo mode for Google Cardboard). 
 The developing WebVR specification~\cite{WebVR} provides interfaces to VR hardware via the browser. A powerful framework for
 development of VR applications for various devices using the browser is A-Frame~\cite{AFrame}. A-Frame has support for several device controllers as well,
@@ -926,8 +926,8 @@ such as for the Daydream and Oculus. CMS is exploring the possibilites of A-Fram
 browser for both VR and AR ({\it e.g.}\ CMS A-Frame prototype~\cite{CMSAFrame}).
 
 VR and AR applications could be used, in principle, to build event displays and data visualization tools for research work as well.
-However the current data access model prevents a straightforward use of those technologies together with the experiments' software frameworks.
-Future client-server approach to data access could fill the current gap and let developers build new VR and AR tools with HEP physicists as end-user targets.
+However, the current data access model prevents a straightforward use of those technologies together with the experiments' software frameworks.
+A future client-server approach to data access could fill the current gap and let developers build new VR and AR tools targeting HEP physicists as end users.
 
 \hypertarget{mobile-tech}{%
 \subsubsection{Mobile technologies}\label{mobile-tech}}

--- a/documents/CWP/cwp-wg-visualization.tex
+++ b/documents/CWP/cwp-wg-visualization.tex
@@ -957,19 +957,19 @@ client-server tools and data exchange formats among HEP experiments in the near 
 \hypertarget{multi-user}{%
 \subsubsection{Multi-user applications}\label{multi-user}}
 
-Nowadays multi-users technology is used in many applications: for example in GoogleDocs, where many users can simultaneously
-interact with the same document. What we would like to provide is a multi-user support for visualization to let several users
-explore and interact with events at the same time. Beside being a useful feature for expert users (for example, when asking for an advise on the visualization of a piece of detector to another person at a distant institute), it could be important for
-Outreach and Education activities, where people or students could interact together with an event display, or for virtual guided tours.
-Game engines offer multi-users support natively, thus we could starting explore their usage.
+Nowadays multi-user technology is used in many applications: for example in GoogleDocs, where many users can simultaneously
+interact with the same document. What we would like to provide is multi-user support for visualization to let several users
+explore and interact with events at the same time. Beside being a useful feature for expert users (for example, when asking for advice on the visualization of a piece of detector to another person at a distant institute), it could be important for
+outreach and education activities, where students and other people could interact together with an event display, or for virtual guided tours.
+Game engines offer multi-user support natively, thus we could starting explore their usage.
 An example of such collaborative features in a 3D environment is integrated in the Med3D visualization framework~\cite{Bohak2017}.
 
 \hypertarget{sharing-knowledge}{%
 \section{Sharing knowledge and fostering collaboration}\label{sharing-knowledge}}
 
 During the kick-starter meetings and the different workshops organized to start and develop the present Community White Paper,
-the whole HSF Visualization Working Group has agreed on the importance of sharing the knowledge among the whole HEP community,
-as well as the best practices and the know-how. Too often, in fact, solutions and tools developed for one HEP experiment are
+the whole HSF Visualization Working Group has agreed on the importance of sharing knowledge among the whole HEP community,
+as well as best practices and know-how. Too often, in fact, solutions and tools developed for one HEP experiment are
 not sufficiently advertised to the rest of the HEP Visualization community, with the result that the community base knowledge
 is fragmented and not efficiently exploited.
 
@@ -985,7 +985,7 @@ show their work and share their solutions. In addition, external experts from in
 advancements in the field and best practices \cite{HSFViz2017}.
 
 It was the first topical workshop focused on HEP Visualization in many years. Many HEP
-experiments and communities showed their latest developments. Given the high number of presentations, a second mini-workshop~\cite{HSFViz2017Mini} has been organized has a follow-up, to let the remaining communities to present their work.
+experiments and communities showed their latest developments. Given the high number of presentations, a second mini-workshop~\cite{HSFViz2017Mini} has been organized as a follow-up, to let the remaining communities to present their work.
 
 The Working Group agreed on the importance of meeting to share findings, knowledge and solutions; and it was decided to
 try to organize a topical workshop on HEP visualization once per year.


### PR DESCRIPTION
Fixing various typos and minor English usage errors, e.g. missing or extra "the".